### PR TITLE
Add description and robots meta tag to layout HEAD

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,6 +3,8 @@
   <head>
     <meta charset="UTF-8">
     <title>Champaign-Urbana Python User's group</title>
+    <meta name="description" content="{{ page.title }}">
+    <meta name="robots" content="index,follow">
 
     <link rel="alternate" type="application/atom+xml" title="Py-CU Events RSS Feed" href="/feeds/rss.xml" />
     <link rel="alternate" type="application/rss+xml" title="Py-CU Events Atom Feed" href="/feeds/atom.xml" />


### PR DESCRIPTION
Just makes user's experience on search engines more in our control (as many search engines will use the description to show to the user in the results page).
